### PR TITLE
Add FastAPI faster-whisper transcription server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your_openai_api_key_here
+LOCAL_TRANSCRIBE_BASE_URL=http://localhost:8000
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -57,3 +57,58 @@ Example JSON response:
   ]
 }
 ```
+
+## Node.js merge backend
+
+An Express-based helper service is included to call the local faster-whisper server in Japanese, English, and Chinese, then merge high-quality transcripts via the OpenAI API.
+
+### Setup
+1. Install Node.js dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the environment example and set your OpenAI API key:
+   ```bash
+   cp .env.example .env
+   # edit .env to set OPENAI_API_KEY
+   ```
+3. Ensure the Python faster-whisper server is running at `LOCAL_TRANSCRIBE_BASE_URL` (default `http://localhost:8000`).
+
+### Running the server
+Start the Node.js service:
+```bash
+npm start
+```
+The server listens on `PORT` (default `3001`).
+
+### API usage
+Send audio to the merge endpoint:
+```bash
+curl -X POST http://localhost:3001/api/transcribe-and-merge \
+  -F "audio=@sample.wav" \
+  -F "model=medium"
+```
+
+### Response format
+The service returns the three candidate transcripts and the merged evaluation:
+```json
+{
+  "candidates": [
+    { "lang": "ja", "text": "...", "raw": { /* local server response */ } },
+    { "lang": "en", "text": "...", "raw": { /* local server response */ } },
+    { "lang": "zh", "text": "...", "raw": { /* local server response */ } }
+  ],
+  "evaluation": {
+    "evaluations": [
+      { "lang": "ja", "quality": "good" },
+      { "lang": "en", "quality": "good" },
+      { "lang": "zh", "quality": "bad" }
+    ],
+    "final": {
+      "ja": "<final merged Japanese>",
+      "en": "<final merged English>",
+      "zh": "<final merged Chinese>"
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# 20251203_faster_whisper_app
+# Local Faster-Whisper Transcription API
+
+A small FastAPI server that exposes an OpenAI-style audio transcription endpoint powered by `faster-whisper`.
+
+## Features
+- POST `/v1/audio/transcriptions` compatible with OpenAI's Whisper API style.
+- Accepts common audio formats via `multipart/form-data`.
+- Uses `faster-whisper` for speech-to-text with configurable model size and language.
+- CORS enabled for local development.
+
+## Setup
+1. *(Optional)* Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running the server
+Start the FastAPI app with uvicorn:
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+## API usage
+Send audio to the transcription endpoint:
+```bash
+curl -X POST http://localhost:8000/v1/audio/transcriptions \
+  -F "file=@sample.mp3" \
+  -F "model=medium" \
+  -F "language=ja"
+```
+
+### Request parameters
+- `file` (required): Audio file upload (mp3, wav, m4a, etc.).
+- `model` (optional): Faster-whisper model size/path (default: `medium`).
+- `language` (optional): ISO language code (e.g., `en`, `ja`, `zh`) or `auto` (default).
+- `response_format` (optional): Only `json` is supported.
+
+### Response format
+Example JSON response:
+```json
+{
+  "text": "Full transcription text",
+  "language": "en",
+  "duration": 12.34,
+  "segments": [
+    {
+      "id": 0,
+      "start": 0.0,
+      "end": 4.0,
+      "text": "Segment text"
+    }
+  ]
+}
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict, List
+
+import shutil
+
+import ctranslate2
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from faster_whisper import WhisperModel
+
+app = FastAPI(title="Local Faster-Whisper Transcription API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost",
+        "http://localhost:3000",
+        "http://127.0.0.1",
+        "http://127.0.0.1:3000",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+DEFAULT_MODEL_NAME = "medium"
+model_cache: Dict[str, WhisperModel] = {}
+
+
+def _select_device() -> str:
+    return "cuda" if ctranslate2.get_device_count("cuda") > 0 else "cpu"
+
+
+def _compute_type_for_device(device: str) -> str:
+    return "float16" if device == "cuda" else "int8"
+
+
+def _load_model(model_size: str) -> WhisperModel:
+    if model_size not in model_cache:
+        device = _select_device()
+        model_cache[model_size] = WhisperModel(
+            model_size,
+            device=device,
+            compute_type=_compute_type_for_device(device),
+        )
+    return model_cache[model_size]
+
+
+@app.on_event("startup")
+def preload_default_model() -> None:
+    _load_model(DEFAULT_MODEL_NAME)
+
+
+def _transcribe_file(file_path: str, model_size: str, language: str) -> dict:
+    model = _load_model(model_size)
+    language_arg = None if language.lower() == "auto" else language
+
+    segments, info = model.transcribe(
+        file_path,
+        language=language_arg,
+        beam_size=5,
+    )
+
+    segment_list: List[dict] = []
+    full_text_parts: List[str] = []
+
+    for idx, segment in enumerate(segments):
+        text = segment.text.strip()
+        segment_list.append(
+            {
+                "id": idx,
+                "start": segment.start,
+                "end": segment.end,
+                "text": text,
+            }
+        )
+        full_text_parts.append(text)
+
+    full_text = " ".join(full_text_parts).strip()
+
+    return {
+        "text": full_text,
+        "language": language_arg or info.language,
+        "duration": info.duration,
+        "segments": segment_list,
+    }
+
+
+@app.post("/v1/audio/transcriptions")
+async def create_transcription(
+    file: UploadFile = File(...),
+    model: str = Form(DEFAULT_MODEL_NAME),
+    language: str = Form("auto"),
+    response_format: str = Form("json"),
+):
+    if response_format.lower() != "json":
+        raise HTTPException(status_code=400, detail="Only json response_format is supported")
+
+    if not file:
+        raise HTTPException(status_code=400, detail="No file provided for transcription")
+
+    temp_path = None
+    try:
+        suffix = Path(file.filename).suffix if file.filename else ".tmp"
+        with NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            shutil.copyfileobj(file.file, temp_file)
+            temp_path = temp_file.name
+
+        transcription = _transcribe_file(temp_path, model, language)
+        return transcription
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail="Transcription failed") from exc
+    finally:
+        if temp_path:
+            try:
+                Path(temp_path).unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "faster-whisper-merge-backend",
+  "version": "1.0.0",
+  "description": "Node.js backend to call local faster-whisper server in multiple languages and merge via OpenAI",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.56.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+faster-whisper
+python-multipart

--- a/server.js
+++ b/server.js
@@ -1,0 +1,123 @@
+import dotenv from 'dotenv';
+import express from 'express';
+import multer from 'multer';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import fetch, { FormData } from 'node-fetch';
+import OpenAI from 'openai';
+
+dotenv.config();
+
+const LOCAL_TRANSCRIBE_BASE_URL = process.env.LOCAL_TRANSCRIBE_BASE_URL || 'http://localhost:8000';
+const PORT = process.env.PORT || 3001;
+const uploadDir = path.join(process.cwd(), 'tmp');
+
+await fsPromises.mkdir(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (_req, file, cb) => {
+    const safeName = `${Date.now()}-${file.originalname}`;
+    cb(null, safeName);
+  },
+});
+
+const upload = multer({ storage });
+
+const app = express();
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function callLocalTranscribe(languageCode, filePath, model) {
+  const formData = new FormData();
+  formData.append('file', fs.createReadStream(filePath), path.basename(filePath));
+  formData.append('model', model || 'medium');
+  formData.append('language', languageCode);
+  formData.append('response_format', 'json');
+
+  const response = await fetch(`${LOCAL_TRANSCRIBE_BASE_URL}/v1/audio/transcriptions`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Local transcription failed for ${languageCode}: ${response.status} ${text}`);
+  }
+
+  const data = await response.json();
+  return {
+    lang: languageCode,
+    text: data?.text || '',
+    raw: data,
+  };
+}
+
+function buildUserPrompt(candidates) {
+  const candidateLines = candidates
+    .map((c, idx) => `${idx + 1}) lang: ${c.lang}, text: "${c.text}"`)
+    .join('\n');
+
+  return (
+    'We have three candidate transcripts for the same audio.\n' +
+    candidateLines +
+    '\nFor each candidate, decide if it is "good" (linguistically coherent and meaningful) or "bad" (nonsense, wrong language, or unusable). ' +
+    'Using only the "good" candidates, reconstruct the best possible content of the original speech and produce final merged versions in Japanese (ja), English (en), and Chinese (zh). ' +
+    'Return JSON only with this schema:\n' +
+    '{\n  "evaluations": [\n    { "lang": "ja", "quality": "good" | "bad" },\n    { "lang": "en", "quality": "good" | "bad" },\n    { "lang": "zh", "quality": "good" | "bad" }\n  ],\n  "final": {\n    "ja": "<final merged Japanese>",\n    "en": "<final merged English>",\n    "zh": "<final merged Chinese>"\n  }\n}'
+  );
+}
+
+app.post('/api/transcribe-and-merge', upload.single('audio'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'Audio file is required' });
+  }
+
+  const filePath = req.file.path;
+  const requestedModel = req.body?.model;
+
+  try {
+    const targetLanguages = ['ja', 'en', 'zh'];
+    const candidates = await Promise.all(
+      targetLanguages.map((lang) => callLocalTranscribe(lang, filePath, requestedModel))
+    );
+
+    const systemMessage = {
+      role: 'system',
+      content: 'You are a strict evaluator and translator. You must respond with valid JSON only.',
+    };
+
+    const userMessage = { role: 'user', content: buildUserPrompt(candidates) };
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [systemMessage, userMessage],
+      response_format: { type: 'json_object' },
+    });
+
+    const content = completion.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error('Empty response from OpenAI');
+    }
+
+    let evaluation;
+    try {
+      evaluation = JSON.parse(content);
+    } catch (err) {
+      throw new Error(`Failed to parse OpenAI JSON: ${err.message}`);
+    }
+
+    return res.json({ candidates, evaluation });
+  } catch (err) {
+    console.error('[transcribe-and-merge] Error:', err);
+    return res.status(500).json({ error: 'Transcription or merge failed' });
+  } finally {
+    if (filePath) {
+      await fsPromises.unlink(filePath).catch(() => {});
+    }
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add FastAPI server exposing an OpenAI-style /v1/audio/transcriptions endpoint powered by faster-whisper
- cache models with default preload and return JSON responses compatible with Whisper API expectations
- document setup, dependencies, and usage instructions in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb3d583d48326b871b51f6d515c84)