### PR TITLE
Improve Node server robustness and startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your_openai_api_key_here
+LOCAL_TRANSCRIBE_BASE_URL=http://localhost:8000
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -1,1 +1,114 @@
-# 20251203_faster_whisper_app
+# Local Faster-Whisper Transcription API
+
+A small FastAPI server that exposes an OpenAI-style audio transcription endpoint powered by `faster-whisper`.
+
+## Features
+- POST `/v1/audio/transcriptions` compatible with OpenAI's Whisper API style.
+- Accepts common audio formats via `multipart/form-data`.
+- Uses `faster-whisper` for speech-to-text with configurable model size and language.
+- CORS enabled for local development.
+
+## Setup
+1. *(Optional)* Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running the server
+Start the FastAPI app with uvicorn:
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+## API usage
+Send audio to the transcription endpoint:
+```bash
+curl -X POST http://localhost:8000/v1/audio/transcriptions \
+  -F "file=@sample.mp3" \
+  -F "model=medium" \
+  -F "language=ja"
+```
+
+### Request parameters
+- `file` (required): Audio file upload (mp3, wav, m4a, etc.).
+- `model` (optional): Faster-whisper model size/path (default: `medium`).
+- `language` (optional): ISO language code (e.g., `en`, `ja`, `zh`) or `auto` (default).
+- `response_format` (optional): Only `json` is supported.
+
+### Response format
+Example JSON response:
+```json
+{
+  "text": "Full transcription text",
+  "language": "en",
+  "duration": 12.34,
+  "segments": [
+    {
+      "id": 0,
+      "start": 0.0,
+      "end": 4.0,
+      "text": "Segment text"
+    }
+  ]
+}
+```
+
+## Node.js merge backend
+
+An Express-based helper service is included to call the local faster-whisper server in Japanese, English, and Chinese, then merge high-quality transcripts via the OpenAI API.
+
+### Setup
+1. Install Node.js dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the environment example and set your OpenAI API key:
+   ```bash
+   cp .env.example .env
+   # edit .env to set OPENAI_API_KEY
+   ```
+3. Ensure the Python faster-whisper server is running at `LOCAL_TRANSCRIBE_BASE_URL` (default `http://localhost:8000`).
+
+### Running the server
+Start the Node.js service:
+```bash
+npm start
+```
+The server listens on `PORT` (default `3001`).
+
+### API usage
+Send audio to the merge endpoint:
+```bash
+curl -X POST http://localhost:3001/api/transcribe-and-merge \
+  -F "audio=@sample.wav" \
+  -F "model=medium"
+```
+
+### Response format
+The service returns the three candidate transcripts and the merged evaluation:
+```json
+{
+  "candidates": [
+    { "lang": "ja", "text": "...", "raw": { /* local server response */ } },
+    { "lang": "en", "text": "...", "raw": { /* local server response */ } },
+    { "lang": "zh", "text": "...", "raw": { /* local server response */ } }
+  ],
+  "evaluation": {
+    "evaluations": [
+      { "lang": "ja", "quality": "good" },
+      { "lang": "en", "quality": "good" },
+      { "lang": "zh", "quality": "bad" }
+    ],
+    "final": {
+      "ja": "<final merged Japanese>",
+      "en": "<final merged English>",
+      "zh": "<final merged Chinese>"
+    }
+  }
+}
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict, List
+
+import shutil
+
+import ctranslate2
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from faster_whisper import WhisperModel
+
+app = FastAPI(title="Local Faster-Whisper Transcription API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost",
+        "http://localhost:3000",
+        "http://127.0.0.1",
+        "http://127.0.0.1:3000",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+DEFAULT_MODEL_NAME = "medium"
+model_cache: Dict[str, WhisperModel] = {}
+
+
+def _select_device() -> str:
+    return "cuda" if ctranslate2.get_device_count("cuda") > 0 else "cpu"
+
+
+def _compute_type_for_device(device: str) -> str:
+    return "float16" if device == "cuda" else "int8"
+
+
+def _load_model(model_size: str) -> WhisperModel:
+    if model_size not in model_cache:
+        device = _select_device()
+        model_cache[model_size] = WhisperModel(
+            model_size,
+            device=device,
+            compute_type=_compute_type_for_device(device),
+        )
+    return model_cache[model_size]
+
+
+@app.on_event("startup")
+def preload_default_model() -> None:
+    _load_model(DEFAULT_MODEL_NAME)
+
+
+def _transcribe_file(file_path: str, model_size: str, language: str) -> dict:
+    model = _load_model(model_size)
+    language_arg = None if language.lower() == "auto" else language
+
+    segments, info = model.transcribe(
+        file_path,
+        language=language_arg,
+        beam_size=5,
+    )
+
+    segment_list: List[dict] = []
+    full_text_parts: List[str] = []
+
+    for idx, segment in enumerate(segments):
+        text = segment.text.strip()
+        segment_list.append(
+            {
+                "id": idx,
+                "start": segment.start,
+                "end": segment.end,
+                "text": text,
+            }
+        )
+        full_text_parts.append(text)
+
+    full_text = " ".join(full_text_parts).strip()
+
+    return {
+        "text": full_text,
+        "language": language_arg or info.language,
+        "duration": info.duration,
+        "segments": segment_list,
+    }
+
+
+@app.post("/v1/audio/transcriptions")
+async def create_transcription(
+    file: UploadFile = File(...),
+    model: str = Form(DEFAULT_MODEL_NAME),
+    language: str = Form("auto"),
+    response_format: str = Form("json"),
+):
+    if response_format.lower() != "json":
+        raise HTTPException(status_code=400, detail="Only json response_format is supported")
+
+    if not file:
+        raise HTTPException(status_code=400, detail="No file provided for transcription")
+
+    temp_path = None
+    try:
+        suffix = Path(file.filename).suffix if file.filename else ".tmp"
+        with NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+            shutil.copyfileobj(file.file, temp_file)
+            temp_path = temp_file.name
+
+        transcription = _transcribe_file(temp_path, model, language)
+        return transcription
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail="Transcription failed") from exc
+    finally:
+        if temp_path:
+            try:
+                Path(temp_path).unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "faster-whisper-merge-backend",
+  "version": "1.0.0",
+  "description": "Node.js backend to call local faster-whisper server in multiple languages and merge via OpenAI",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.56.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi-language Transcription &amp; Merge</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="header">
+      <h1>Multi-language Transcription &amp; Merge</h1>
+      <p class="subtitle">Upload audio, transcribe in ja/en/zh, and merge the best results.</p>
+    </header>
+
+    <main class="main">
+      <section class="card">
+        <h2>Upload Audio</h2>
+        <form id="transcribe-form" class="form" enctype="multipart/form-data">
+          <div class="form-row">
+            <label for="audio">Audio File</label>
+            <input id="audio" name="audio" type="file" accept="audio/*" required />
+          </div>
+          <div class="form-row">
+            <label for="model">Whisper Model (optional)</label>
+            <input id="model" name="model" type="text" placeholder="e.g. small, base, medium" />
+          </div>
+          <div class="actions">
+            <button id="submit-btn" type="submit">Transcribe &amp; Merge</button>
+            <span id="status" class="status">Idle</span>
+          </div>
+          <div id="error" class="error" role="alert" aria-live="polite"></div>
+        </form>
+      </section>
+
+      <section class="grid">
+        <div class="card">
+          <h2>Candidates</h2>
+          <div id="candidates" class="candidates empty">No results yet.</div>
+        </div>
+        <div class="card">
+          <h2>Evaluation</h2>
+          <div id="evaluation" class="evaluation empty">No evaluation yet.</div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Final Merged Texts</h2>
+        <div class="final-grid">
+          <div class="final-block">
+            <label for="final-ja">Japanese (ja)</label>
+            <textarea id="final-ja" readonly placeholder="N/A"></textarea>
+          </div>
+          <div class="final-block">
+            <label for="final-en">English (en)</label>
+            <textarea id="final-en" readonly placeholder="N/A"></textarea>
+          </div>
+          <div class="final-block">
+            <label for="final-zh">Chinese (zh)</label>
+            <textarea id="final-zh" readonly placeholder="N/A"></textarea>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,145 @@
+(() => {
+  const form = document.getElementById('transcribe-form');
+  const fileInput = document.getElementById('audio');
+  const modelInput = document.getElementById('model');
+  const submitBtn = document.getElementById('submit-btn');
+  const statusEl = document.getElementById('status');
+  const errorEl = document.getElementById('error');
+  const candidatesEl = document.getElementById('candidates');
+  const evaluationEl = document.getElementById('evaluation');
+  const finalJa = document.getElementById('final-ja');
+  const finalEn = document.getElementById('final-en');
+  const finalZh = document.getElementById('final-zh');
+
+  const setStatus = (text) => {
+    statusEl.textContent = text;
+  };
+
+  const setError = (msg) => {
+    errorEl.textContent = msg || '';
+  };
+
+  const clearResults = () => {
+    candidatesEl.innerHTML = 'No results yet.';
+    candidatesEl.classList.add('empty');
+    evaluationEl.innerHTML = 'No evaluation yet.';
+    evaluationEl.classList.add('empty');
+    finalJa.value = '';
+    finalEn.value = '';
+    finalZh.value = '';
+  };
+
+  const renderCandidates = (candidates = []) => {
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      candidatesEl.innerHTML = 'No results yet.';
+      candidatesEl.classList.add('empty');
+      return;
+    }
+
+    candidatesEl.classList.remove('empty');
+    candidatesEl.innerHTML = candidates
+      .map(({ lang, text }) => {
+        const safeLang = lang || 'N/A';
+        const safeText = text || 'N/A';
+        return `
+          <div class="candidate-card">
+            <header>
+              <span class="lang">${safeLang}</span>
+            </header>
+            <div class="text">${escapeHtml(safeText)}</div>
+          </div>
+        `;
+      })
+      .join('');
+  };
+
+  const renderEvaluation = (evaluation) => {
+    const evals = evaluation?.evaluations;
+    if (!Array.isArray(evals) || evals.length === 0) {
+      evaluationEl.innerHTML = 'No evaluation yet.';
+      evaluationEl.classList.add('empty');
+      return;
+    }
+
+    evaluationEl.classList.remove('empty');
+    const rows = evals
+      .map(({ lang, quality }) => {
+        const safeLang = lang || 'N/A';
+        const safeQuality = quality || 'N/A';
+        const qualityClass = safeQuality === 'good' ? 'eval-good' : safeQuality === 'bad' ? 'eval-bad' : '';
+        return `<tr><td>${safeLang}</td><td class="${qualityClass}">${safeQuality}</td></tr>`;
+      })
+      .join('');
+
+    evaluationEl.innerHTML = `
+      <table class="eval-table">
+        <thead>
+          <tr><th>Lang</th><th>Quality</th></tr>
+        </thead>
+        <tbody>
+          ${rows}
+        </tbody>
+      </table>
+    `;
+  };
+
+  const renderFinalTexts = (finalObj = {}) => {
+    finalJa.value = finalObj.ja || '';
+    finalEn.value = finalObj.en || '';
+    finalZh.value = finalObj.zh || '';
+  };
+
+  const escapeHtml = (unsafe) => {
+    return unsafe
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  };
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    setError('');
+
+    const file = fileInput.files?.[0];
+    if (!file) {
+      setError('Please select an audio file.');
+      return;
+    }
+
+    clearResults();
+    setStatus('Processing...');
+    submitBtn.disabled = true;
+
+    const formData = new FormData();
+    formData.append('audio', file);
+    if (modelInput.value.trim()) {
+      formData.append('model', modelInput.value.trim());
+    }
+
+    try {
+      const response = await fetch('/api/transcribe-and-merge', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Request failed');
+      }
+
+      const data = await response.json();
+      renderCandidates(data?.candidates);
+      renderEvaluation(data?.evaluation);
+      renderFinalTexts(data?.evaluation?.final || {});
+      setStatus('Done');
+    } catch (err) {
+      console.error(err);
+      setError(err?.message || 'Something went wrong. Please try again.');
+      setStatus('Error');
+    } finally {
+      submitBtn.disabled = false;
+    }
+  });
+})();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,248 @@
+:root {
+  --bg: #f6f7fb;
+  --card-bg: #ffffff;
+  --border: #e2e5ec;
+  --text: #1f2d3d;
+  --muted: #5f6b7a;
+  --accent: #3b82f6;
+  --error: #d14343;
+  --success: #15803d;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 20% 20%, #eef2ff 0, transparent 25%),
+    radial-gradient(circle at 80% 0%, #e0f2fe 0, transparent 20%),
+    var(--bg);
+  color: var(--text);
+}
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 32px 16px 48px;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+.main {
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 18px;
+}
+
+.form {
+  display: grid;
+  gap: 12px;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+label {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+input[type="file"],
+input[type="text"],
+button,
+textarea {
+  font-family: inherit;
+}
+
+input[type="file"],
+input[type="text"] {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fbfcff;
+}
+
+input[type="text"]:focus {
+  outline: 2px solid #dbeafe;
+  border-color: #bfdbfe;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+button {
+  padding: 10px 16px;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(59, 130, 246, 0.25);
+  transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.25);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.status {
+  font-weight: 600;
+  color: var(--muted);
+  padding: 6px 10px;
+  background: #f4f6fb;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.error {
+  color: var(--error);
+  min-height: 20px;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.candidates, .evaluation {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.empty {
+  color: var(--muted);
+}
+
+.candidate-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #fafbff;
+}
+
+.candidate-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.candidate-card .lang {
+  font-weight: 700;
+}
+
+.candidate-card .text {
+  white-space: pre-wrap;
+  max-height: 140px;
+  overflow: auto;
+  color: var(--text);
+}
+
+.eval-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.eval-table th,
+.eval-table td {
+  border: 1px solid var(--border);
+  padding: 8px;
+  text-align: left;
+}
+
+.eval-good {
+  color: var(--success);
+  font-weight: 700;
+}
+
+.eval-bad {
+  color: var(--error);
+  font-weight: 700;
+}
+
+.final-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 12px;
+}
+
+.final-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+textarea {
+  min-height: 120px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fdfefe;
+  resize: vertical;
+  line-height: 1.4;
+}
+
+@media (max-width: 600px) {
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+faster-whisper
+python-multipart

--- a/server.js
+++ b/server.js
@@ -1,0 +1,146 @@
+import dotenv from 'dotenv';
+import express from 'express';
+import multer from 'multer';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import fetch, { FormData } from 'node-fetch';
+import OpenAI from 'openai';
+import { fileURLToPath } from 'url';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const LOCAL_TRANSCRIBE_BASE_URL = process.env.LOCAL_TRANSCRIBE_BASE_URL || 'http://localhost:8000';
+const PORT = process.env.PORT || 3001;
+const uploadDir = path.join(process.cwd(), 'tmp');
+const publicDir = path.join(process.cwd(), 'public');
+
+if (!process.env.OPENAI_API_KEY) {
+  console.error('[startup] OPENAI_API_KEY is not set in environment variables.');
+  process.exit(1);
+}
+
+const app = express();
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (_req, file, cb) => {
+    const safeName = `${Date.now()}-${file.originalname}`;
+    cb(null, safeName);
+  },
+});
+
+const upload = multer({ storage });
+
+app.use(express.static(publicDir));
+
+async function callLocalTranscribe(languageCode, filePath, model) {
+  const formData = new FormData();
+  formData.append('file', fs.createReadStream(filePath), path.basename(filePath));
+  formData.append('model', model || 'small');
+  formData.append('language', languageCode);
+  formData.append('response_format', 'json');
+
+  const response = await fetch(`${LOCAL_TRANSCRIBE_BASE_URL}/v1/audio/transcriptions`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Local transcription failed for ${languageCode}: ${response.status} ${body}`);
+  }
+
+  const data = await response.json();
+  return {
+    lang: languageCode,
+    text: data?.text || '',
+    raw: data,
+  };
+}
+
+function buildUserPrompt(candidates) {
+  const candidateLines = candidates
+    .map((c, idx) => `${idx + 1}) lang: ${c.lang}, text: "${c.text}"`)
+    .join('\n');
+
+  return (
+    'We have three candidate transcripts for the same audio.\n' +
+    candidateLines +
+    '\nFor each candidate, decide if it is "good" (linguistically coherent and meaningful) or "bad" (nonsense, wrong language, or unusable). ' +
+    'Using only the "good" candidates, reconstruct the best possible content of the original speech and produce final merged versions in Japanese (ja), English (en), and Chinese (zh). ' +
+    'Return JSON only with this schema:\n' +
+    '{\n  "evaluations": [\n    { "lang": "ja", "quality": "good" | "bad" },\n    { "lang": "en", "quality": "good" | "bad" },\n    { "lang": "zh", "quality": "good" | "bad" }\n  ],\n  "final": {\n    "ja": "<final merged Japanese>",\n    "en": "<final merged English>",\n    "zh": "<final merged Chinese>"\n  }\n}'
+  );
+}
+
+app.post('/api/transcribe-and-merge', upload.single('audio'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'Audio file is required' });
+  }
+
+  const filePath = req.file.path;
+  const requestedModel = req.body?.model;
+
+  try {
+    const targetLanguages = ['ja', 'en', 'zh'];
+    const candidates = await Promise.all(
+      targetLanguages.map((lang) => callLocalTranscribe(lang, filePath, requestedModel))
+    );
+
+    const systemMessage = {
+      role: 'system',
+      content: 'You are a strict evaluator and translator. You must respond with valid JSON only.',
+    };
+
+    const userMessage = { role: 'user', content: buildUserPrompt(candidates) };
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [systemMessage, userMessage],
+      response_format: { type: 'json_object' },
+    });
+
+    const content = completion.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error('Empty response from OpenAI');
+    }
+
+    let evaluation;
+    try {
+      evaluation = JSON.parse(content);
+    } catch (err) {
+      throw new Error(`Failed to parse OpenAI JSON: ${err.message}`);
+    }
+
+    return res.json({ candidates, evaluation });
+  } catch (err) {
+    console.error('[transcribe-and-merge] Error:', err);
+    return res.status(500).json({ error: 'Transcription or merge failed' });
+  } finally {
+    if (filePath) {
+      await fsPromises.unlink(filePath).catch(() => {});
+    }
+  }
+});
+
+async function start() {
+  try {
+    await fsPromises.mkdir(uploadDir, { recursive: true });
+    console.log(`[startup] uploadDir ensured at ${uploadDir}`);
+  } catch (err) {
+    console.error('[startup] Failed to ensure uploadDir:', err);
+    process.exit(1);
+  }
+
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+    console.log(`Serving static files from ${publicDir}`);
+  });
+}
+
+start();


### PR DESCRIPTION
## Summary
- add startup validation for OPENAI_API_KEY and ensure upload directory exists before requests
- serve static frontend assets and default to the lighter 'small' model when calling the local transcriber
- maintain structured OpenAI prompts/parsing with consistent error handling and cleanup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb3d583d48326b871b51f6d515c84)